### PR TITLE
fix missing name for Munich Dunkel

### DIFF
--- a/2015_Guidelines_Beer.json
+++ b/2015_Guidelines_Beer.json
@@ -1769,7 +1769,7 @@
             "number": 8,
             "subcategories": [
                 {
-                    "name": "",
+                    "name": "Munich Dunkel",
                     "letter": "A",
                     "guidelines": {
                         "overallImpression": "Characterized by depth, richness and complexity typical of darker Munich malts with the accompanying Maillard products. Deeply bready-toasty, often with chocolate-like flavors in the freshest examples, but never harsh, roasty, or astringent; a decidedly malt-balanced beer, yet still easily drinkable.",


### PR DESCRIPTION
I've fixed the missing style name "Munich Dunkel."  I have also submitted a similar change to https://github.com/Boo-urns/bjcp, which is available on npm.